### PR TITLE
lower quantity of PRs per query to avoid timeouts

### DIFF
--- a/src/bitcoin_acks/github_data/graphql_queries/pull_requests.graphql
+++ b/src/bitcoin_acks/github_data/graphql_queries/pull_requests.graphql
@@ -1,7 +1,7 @@
 query(
 $repositoryPath: String = "bitcoin",
 $repositoryName: String = "bitcoin",
-$prFirst: Int = 100,
+$prFirst: Int = 20,
 $prLast: Int = null,
 $prCursorAfter: String = null,
 $prCursorBefore: String = null,

--- a/src/bitcoin_acks/github_data/pull_requests_data.py
+++ b/src/bitcoin_acks/github_data/pull_requests_data.py
@@ -16,6 +16,9 @@ from bitcoin_acks.models import PullRequests
 
 
 class PullRequestsData(RepositoriesData):
+
+    MAX_PRS = 20
+
     def __init__(self, repository_path: str, repository_name: str):
         super(PullRequestsData, self).__init__(repository_path=repository_path,
                                                repository_name=repository_name)
@@ -41,9 +44,9 @@ class PullRequestsData(RepositoriesData):
         while limit is None or received < limit:
 
             if limit is None:
-                quantity = 100
+                quantity = self.MAX_PRS
             else:
-                quantity = min(limit - received, 100)
+                quantity = min(limit - received, self.MAX_PRS)
 
             if last_cursor is not None and not newest_first:
                 variables['prCursorAfter'] = last_cursor


### PR DESCRIPTION
In response to https://platform.github.community/t/sporadic-502s-fetching-pr-data/3024/8