### PR TITLE
Add "tooting" capability

### DIFF
--- a/src/bitcoin_acks/models/__init__.py
+++ b/src/bitcoin_acks/models/__init__.py
@@ -7,4 +7,5 @@ from .pull_requests import PullRequests
 from .pull_requests_labels import PullRequestsLabels
 from .repositories import Repositories
 from .tweets import Tweets
+from .toots import Toots
 from .users import Users

--- a/src/bitcoin_acks/models/pull_requests.py
+++ b/src/bitcoin_acks/models/pull_requests.py
@@ -57,6 +57,7 @@ class PullRequests(Base):
     repository_id = Column(Integer, nullable=False)
     author_id = Column(String)
     tweet_id = Column(Integer, unique=True)
+    toot_id = Column(Integer, unique=True)
 
     author = relationship(Users,
                           primaryjoin=author_id == Users.id,

--- a/src/bitcoin_acks/models/toots.py
+++ b/src/bitcoin_acks/models/toots.py
@@ -1,0 +1,14 @@
+import datetime
+
+from sqlalchemy import Column, DateTime, Integer
+
+from bitcoin_acks.database.base import Base
+
+
+class Toots(Base):
+    __tablename__ = 'toots'
+
+    id = Column(Integer, primary_key=True)
+    timestamp = Column(DateTime, nullable=False,
+                       default=datetime.datetime.utcnow, )
+    pull_request_id = Column(Integer, nullable=False, unique=True)

--- a/src/bitcoin_acks/scripts/send_toot.py
+++ b/src/bitcoin_acks/scripts/send_toot.py
@@ -1,0 +1,84 @@
+import datetime
+import os
+
+import requests
+from mastodon import Mastodon
+
+from bitcoin_acks.database.session import session_scope
+from bitcoin_acks.models import PullRequests
+from bitcoin_acks.models.toots import Toots
+
+MASTODON_CREDPATH = os.environ['MASTODON_CREDPATH']
+MASTODON_APPNAME = os.environ['MASTODON_APPNAME']
+MASTODON_INSTANCE = os.environ['MASTODON_INSTANCE']
+MASTODON_USER = os.environ['MASTODON_USER']
+MASTODON_PASS = os.environ['MASTODON_PASS']
+
+CLIENTCRED_FILENAME = 'pytooter_clientcred.secret'
+
+def login():
+    clientcred_file = os.path.join(MASTODON_CREDPATH, CLIENTCRED_FILENAME)
+    if not os.path.isfile(clientcred_file):
+        # create an application (this info is kept at the server side) only once
+        Mastodon.create_app(
+             MASTODON_APPNAME,
+             api_base_url = MASTODON_INSTANCE,
+             to_file = clientcred_file
+        )
+
+    mastodon = Mastodon(
+        client_id = clientcred_file,
+        api_base_url = MASTODON_INSTANCE
+    )
+    mastodon.log_in(
+        MASTODON_USER,
+        MASTODON_PASS,
+        # to_file = ... (could cache credentials for next time)
+    )
+    return mastodon
+
+
+def send_toot():
+    with session_scope() as session:
+        now = datetime.datetime.utcnow()
+        yesterday = now - datetime.timedelta(days=1)
+
+        next_pull_request = (
+            session
+                .query(PullRequests)
+                .order_by(PullRequests.merged_at.asc())
+                .filter(PullRequests.merged_at > yesterday)
+                .filter(PullRequests.toot_id.is_(None))
+                .filter(PullRequests.merged_at.isnot(None))
+                .first()
+        )
+        if next_pull_request is None:
+            return
+        mastodon = login()
+
+        commits_url = 'https://api.github.com/repos/bitcoin/bitcoin/commits'
+        params = {'author': next_pull_request.author.login}
+        response = requests.get(commits_url, params=params)
+        response_json = response.json()
+
+        if len(response_json) > 1:
+            status = 'Merged PR from {0}: {1} {2}' \
+                .format(next_pull_request.author.login,
+                        next_pull_request.title,
+                        next_pull_request.html_url)
+        else:
+            status = '''
+            {0}'s first merged PR: {1}
+            Congratulations!  🎉🍾🎆
+            '''.format(next_pull_request.author.login,
+                       next_pull_request.html_url)
+        toot = mastodon.toot(status)
+        new_tweet = Toots()
+        new_tweet.id = toot['id']
+        new_tweet.pull_request_id = next_pull_request.number
+        session.add(new_tweet)
+        next_pull_request.toot_id = toot['id']
+
+
+if __name__ == '__main__':
+    send_toot()


### PR DESCRIPTION
This adds functionality to push messages to mastodon ("tooting"), entirely analogous to the twitter code it adds a script `src/bitcoin_acks/scripts/send_toot.py`.

This depends on Mastodon.py (`pip3 install Mastodon.py`.)